### PR TITLE
fix: ticker dispose problem while enable passing false

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -2,7 +2,7 @@ group 'com.example.overscroll_pop'
 version '1.0-SNAPSHOT'
 
 buildscript {
-    ext.kotlin_version = '1.3.50'
+    ext.kotlin_version = '1.5.20'
     repositories {
         google()
         jcenter()
@@ -25,13 +25,24 @@ apply plugin: 'com.android.library'
 apply plugin: 'kotlin-android'
 
 android {
-    compileSdkVersion 30
+    namespace 'com.example.overscroll_pop'
+    compileSdkVersion 34
 
     sourceSets {
         main.java.srcDirs += 'src/main/kotlin'
     }
+    
     defaultConfig {
         minSdkVersion 16
+    }
+
+    compileOptions {
+        sourceCompatibility JavaVersion.VERSION_1_8
+        targetCompatibility JavaVersion.VERSION_1_8
+    }
+
+    kotlinOptions {
+        jvmTarget = '1.8'
     }
 }
 

--- a/lib/overscroll_pop.dart
+++ b/lib/overscroll_pop.dart
@@ -44,15 +44,8 @@ class OverscrollPop extends StatefulWidget {
 
 class _OverscrollPopState extends State<OverscrollPop>
     with SingleTickerProviderStateMixin {
-  late final AnimationController? _animationController = AnimationController(
-    vsync: this,
-    duration: Duration(milliseconds: 200),
-  )..addStatusListener(_onAnimationEnd);
-
-  late Animation<Offset> _animation = Tween<Offset>(
-    begin: Offset.zero,
-    end: Offset.zero,
-  ).animate(_animationController!);
+  late final AnimationController? _animationController;
+  late Animation<Offset> _animation;
 
   Offset? _dragOffset;
   Offset? _previousPosition;
@@ -60,9 +53,29 @@ class _OverscrollPopState extends State<OverscrollPop>
   bool _isDraggingToPop = false;
 
   @override
+  void initState() {
+    if (widget.enable) {
+      _animationController = AnimationController(
+        vsync: this,
+        duration: Duration(milliseconds: 200),
+      )..addStatusListener(_onAnimationEnd);
+
+      _animation = Tween<Offset>(
+        begin: Offset.zero,
+        end: Offset.zero,
+      ).animate(_animationController!);
+    }
+
+    super.initState();
+  }
+
+  @override
   void dispose() {
-    _animationController?.removeStatusListener(_onAnimationEnd);
-    _animationController?.dispose();
+    if (widget.enable) {
+      _animationController?.removeStatusListener(_onAnimationEnd);
+      _animationController?.dispose();
+    }
+
     super.dispose();
   }
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: overscroll_pop
 description: A Flutter widget for Scrollview, pop when overscroll like Pinterest and Instagram app on iOS
-version: 0.0.9
+version: 0.1.0
 homepage: https://github.com/luunc/overscroll_pop
 
 environment:


### PR DESCRIPTION
Exception:

Looking up a deactivated widget's ancestor is unsafe. At this point the state of the widget's element tree is no longer stable. To safely refer to a widget's ancestor in its dispose() method, save a reference to the ancestor by calling dependOnInheritedWidgetOfExactType() in the widget's didChangeDependencies() method.

StatefulElement#04b6c(DEFUNCT)(no widget, state: _OverscrollPopState#dc799(ticker inactive))

** We are preventing unnecessary ticker creation with this PR.